### PR TITLE
Fix CI: remove broken Railway deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: CI
 
 on:
   push:
@@ -11,93 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          
-      - name: Install Backend Dependencies
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            backend/package-lock.json
+            frontend/package-lock.json
+
+      - name: Install and test backend
         run: |
           cd backend
           npm ci
-          
-      - name: Run Backend Tests
-        run: |
-          cd backend
           npm test
-          
-      - name: Install Frontend Dependencies
-        run: |
-          cd frontend
-          npm ci
-          
-      - name: Build Frontend
-        run: |
-          cd frontend
-          npm run build
-          
-      - name: Build Backend
-        run: |
-          cd backend
           npm run build
 
-  deploy-frontend:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          
-      - name: Install Frontend Dependencies
+      - name: Install and build frontend
         run: |
           cd frontend
           npm ci
-          
-      - name: Build Frontend
-        run: |
-          cd frontend
           npm run build
-          
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: 'view0x'
-          directory: './frontend/dist'
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
-  deploy-backend:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          
-      - name: Install Backend Dependencies
-        run: |
-          cd backend
-          npm ci
-          
-      - name: Build Backend
-        run: |
-          cd backend
-          npm run build
-          
-      - name: Deploy to Railway
-        uses: railwayapp/action@v1.2.0
-        with:
-          service: view0x-backend
-          token: ${{ secrets.RAILWAY_TOKEN }}
+# Production deploy: .github/workflows/deploy-vps.yml (VPS + Docker)


### PR DESCRIPTION
## Summary
- Removes `deploy-backend` job that used `railwayapp/action` (repository no longer found).
- Removes `deploy-frontend` Cloudflare Pages job from this workflow (optional; configure separately if needed).
- Renames workflow to **CI** — backend tests + frontend build only.
- Production VPS deploy remains in `deploy-vps.yml`.

## Test plan
- [ ] CI workflow passes on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by removing the broken Railway deploy and the Cloudflare Pages step. The workflow now only runs backend tests and builds the frontend; production deploy remains in `deploy-vps.yml`.

- **Refactors**
  - Renamed workflow to "CI".
  - Consolidated steps for backend test/build and frontend build.
  - Enabled npm caching via `actions/setup-node@v4` for `backend/package-lock.json` and `frontend/package-lock.json`.

<sup>Written for commit 2d3bfb557f3bedf4c587a21e6135cbeefc045d7f. Summary will update on new commits. <a href="https://cubic.dev/pr/1cbyc/view0x/pull/99?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

